### PR TITLE
generate zdepthConfig.cmake and zdepthConfigVersion.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,12 +83,12 @@ target_link_libraries(zdepth_test PRIVATE zdepth)
 install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX})
 install(FILES README.md DESTINATION ${CMAKE_INSTALL_PREFIX})
 install(DIRECTORY cmake include DESTINATION ${CMAKE_INSTALL_PREFIX})
-install(TARGETS zdepth EXPORT zdepth DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(TARGETS zdepth EXPORT zdepth LIBRARY DESTINATION lib)
 
 ################################################################################
 # Generate zdepthConfig.cmake and zdepthConfigVersion.cmake for cmake projects
 
-set(export_dest_dir "${CMAKE_INSTALL_PREFIX}/lib/cmake/zdepth")
+set(export_dest_dir "lib/cmake/zdepth")
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     zdepthConfigVersion.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,4 +83,28 @@ target_link_libraries(zdepth_test PRIVATE zdepth)
 install(FILES LICENSE DESTINATION ${CMAKE_INSTALL_PREFIX})
 install(FILES README.md DESTINATION ${CMAKE_INSTALL_PREFIX})
 install(DIRECTORY cmake include DESTINATION ${CMAKE_INSTALL_PREFIX})
-install(TARGETS zdepth DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(TARGETS zdepth EXPORT zdepth DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+
+################################################################################
+# Generate zdepthConfig.cmake and zdepthConfigVersion.cmake for cmake projects
+
+set(export_dest_dir "${CMAKE_INSTALL_PREFIX}/lib/cmake/zdepth")
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    zdepthConfigVersion.cmake
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY AnyNewerVersion
+    )
+
+export(TARGETS zdepth zstd
+    NAMESPACE zdepth::
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/zdepthConfig.cmake")
+
+install(EXPORT zdepth
+        DESTINATION ${export_dest_dir}
+        NAMESPACE zdepth::
+        FILE zdepthConfig.cmake)
+
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/zdepthConfigVersion.cmake"
+        DESTINATION "${export_dest_dir}"
+        )

--- a/zstd/CMakeLists.txt
+++ b/zstd/CMakeLists.txt
@@ -25,4 +25,4 @@ target_include_directories(zstd PUBLIC
     "$<INSTALL_INTERFACE:include>"
 )
 
-install(TARGETS zstd EXPORT zdepth DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(TARGETS zstd EXPORT zdepth LIBRARY DESTINATION lib)

--- a/zstd/CMakeLists.txt
+++ b/zstd/CMakeLists.txt
@@ -25,4 +25,4 @@ target_include_directories(zstd PUBLIC
     "$<INSTALL_INTERFACE:include>"
 )
 
-install(TARGETS zstd DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(TARGETS zstd EXPORT zdepth DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)


### PR DESCRIPTION
so users could do

find_package(zdepth)
target_link_libraries(foo zdepth::zdepth)

this corrects issue #4 
