### PR TITLE
Handle Non Block Size Dimension Multiples

### DIFF
--- a/include/zdepth.hpp
+++ b/include/zdepth.hpp
@@ -279,7 +279,7 @@ public:
 
     // Decompress buffer to depth array.
     // Resulting depth buffer is row-first, stride=width*2 (no surprises).
-    // Returns DepthResult::Success if original depth can be recovered
+    // Returns false if input is invalid
     DepthResult Decompress(
         const std::vector<uint8_t>& compressed,
         int& width,

--- a/src/zdepth.cpp
+++ b/src/zdepth.cpp
@@ -525,7 +525,7 @@ void DepthCompressor::CompressImage(
                     }
                 }
             } // next depth pixel
-        }
+        } 
     } // next block
 }
 
@@ -809,7 +809,7 @@ bool DepthCompressor::DecompressImage(
                     row[x] = static_cast<uint16_t>( d );
                 }
             } // next depth pixel
-        }
+        } 
     } // next block
 
     return true;

--- a/src/zdepth.cpp
+++ b/src/zdepth.cpp
@@ -10,9 +10,6 @@ namespace zdepth {
 //------------------------------------------------------------------------------
 // Constants
 
-// Size of a block for predictor selection purposes
-static const int kBlockSize = 8;
-
 // Zstd compression level
 static const int kZstdLevel = 1;
 
@@ -24,6 +21,7 @@ const char* DepthResultString(DepthResult result)
     case DepthResult::WrongFormat: return "WrongFormat";
     case DepthResult::Corrupted: return "Corrupted";
     case DepthResult::MissingPFrame: return "MissingPFrame";
+    case DepthResult::BadDimensions: return "BadDimensions";
     case DepthResult::Success: return "Success";
     default: break;
     }
@@ -329,13 +327,17 @@ void Unpack12(
 //------------------------------------------------------------------------------
 // DepthCompressor
 
-void DepthCompressor::Compress(
+DepthResult DepthCompressor::Compress(
     int width,
     int height,
     const uint16_t* unquantized_depth,
     std::vector<uint8_t>& compressed,
     bool keyframe)
 {
+    if(width % kBlockSize != 0 || height % kBlockSize != 0) {
+        return DepthResult::BadDimensions;
+    }
+
     // Enforce keyframe if we have not compressed anything yet
     if (CompressedFrameNumber == 0) {
         keyframe = true;
@@ -377,6 +379,8 @@ void DepthCompressor::Compress(
     ZstdCompress(Blocks, BlocksOut);
 
     WriteCompressedFile(width, height, keyframe, compressed);
+
+    return DepthResult::Success;
 }
 
 void DepthCompressor::CompressImage(
@@ -520,7 +524,7 @@ void DepthCompressor::CompressImage(
                     }
                 }
             } // next depth pixel
-        } 
+        }
     } // next block
 }
 
@@ -804,7 +808,7 @@ bool DepthCompressor::DecompressImage(
                     row[x] = static_cast<uint16_t>( d );
                 }
             } // next depth pixel
-        } 
+        }
     } // next block
 
     return true;

--- a/src/zdepth.cpp
+++ b/src/zdepth.cpp
@@ -334,6 +334,7 @@ DepthResult DepthCompressor::Compress(
     std::vector<uint8_t>& compressed,
     bool keyframe)
 {
+    // Enforce that image dimensions are multiples of the block size
     if(width % kBlockSize != 0 || height % kBlockSize != 0) {
         return DepthResult::BadDimensions;
     }

--- a/tests/zdepth_test.cpp
+++ b/tests/zdepth_test.cpp
@@ -261,7 +261,7 @@ bool TestFrame(const uint16_t* frame, bool keyframe)
 
     const unsigned original_bytes = Width * Height * 2;
     cout << endl;
-    cout << "Zdepth Compression: " << original_bytes << " bytes -> " << compressed.size() <<
+    cout << "Zdepth Compression: " << original_bytes << " bytes -> " << compressed.size() << 
         " bytes (ratio = " << original_bytes / (float)compressed.size() << ":1) ("
         << (compressed.size() * 30 * 8) / 1000000.f << " Mbps @ 30 FPS)" << endl;
     cout << "Zdepth Speed: Compressed in " << (t1 - t0) / 1000.f << " msec. Decompressed in " << (t2 - t1) / 1000.f << " msec" << endl;
@@ -297,13 +297,13 @@ bool TestFrame(const uint16_t* frame, bool keyframe)
     }
 
     cout << endl;
-    cout << "Quantization+RVL Compression: " << original_bytes << " bytes -> " << compressed.size() <<
+    cout << "Quantization+RVL Compression: " << original_bytes << " bytes -> " << compressed.size() << 
         " bytes (ratio = " << original_bytes / (float)compressed.size() << ":1) ("
         << (compressed.size() * 30 * 8) / 1000000.f << " Mbps @ 30 FPS)" << endl;
     cout << "Quantization+RVL Speed: Compressed in " << (t4 - t3) / 1000.f << " msec. Decompressed in " << (t8 - t7) / 1000.f << " msec" << endl;
 
     cout << endl;
-    cout << "Quantization+RVL+Zstd Compression: " << original_bytes << " bytes -> " << recompressed.size() <<
+    cout << "Quantization+RVL+Zstd Compression: " << original_bytes << " bytes -> " << recompressed.size() << 
         " bytes (ratio = " << original_bytes / (float)recompressed.size() << ":1) ("
         << (recompressed.size() * 30 * 8) / 1000000.f << " Mbps @ 30 FPS)" << endl;
     cout << "Quantization+RVL+Zstd Speed: Compressed in " << (t6 - t5 + t4 - t3) / 1000.f << " msec. Decompressed in " << (t8 - t6) / 1000.f << " msec" << endl;

--- a/tests/zdepth_test.cpp
+++ b/tests/zdepth_test.cpp
@@ -219,6 +219,16 @@ bool TestFrame(const uint16_t* frame, bool keyframe)
 {
     std::vector<uint8_t> compressed;
 
+    if(Width % kBlockSize != 0) {
+        cout << "Failed: Width, " << Width <<  ", is not a multiple of Block Size, " << kBlockSize << endl;
+        return false;
+    }
+
+    if(Height % kBlockSize != 0) {
+        cout << "Failed: Height, " << Height <<  ", is not a multiple of Block Size, " << kBlockSize << endl;
+        return false;
+    }
+
     const uint64_t t0 = GetTimeUsec();
 
     compressor.Compress(Width, Height, frame, compressed, keyframe);
@@ -251,7 +261,7 @@ bool TestFrame(const uint16_t* frame, bool keyframe)
 
     const unsigned original_bytes = Width * Height * 2;
     cout << endl;
-    cout << "Zdepth Compression: " << original_bytes << " bytes -> " << compressed.size() << 
+    cout << "Zdepth Compression: " << original_bytes << " bytes -> " << compressed.size() <<
         " bytes (ratio = " << original_bytes / (float)compressed.size() << ":1) ("
         << (compressed.size() * 30 * 8) / 1000000.f << " Mbps @ 30 FPS)" << endl;
     cout << "Zdepth Speed: Compressed in " << (t1 - t0) / 1000.f << " msec. Decompressed in " << (t2 - t1) / 1000.f << " msec" << endl;
@@ -287,13 +297,13 @@ bool TestFrame(const uint16_t* frame, bool keyframe)
     }
 
     cout << endl;
-    cout << "Quantization+RVL Compression: " << original_bytes << " bytes -> " << compressed.size() << 
+    cout << "Quantization+RVL Compression: " << original_bytes << " bytes -> " << compressed.size() <<
         " bytes (ratio = " << original_bytes / (float)compressed.size() << ":1) ("
         << (compressed.size() * 30 * 8) / 1000000.f << " Mbps @ 30 FPS)" << endl;
     cout << "Quantization+RVL Speed: Compressed in " << (t4 - t3) / 1000.f << " msec. Decompressed in " << (t8 - t7) / 1000.f << " msec" << endl;
 
     cout << endl;
-    cout << "Quantization+RVL+Zstd Compression: " << original_bytes << " bytes -> " << recompressed.size() << 
+    cout << "Quantization+RVL+Zstd Compression: " << original_bytes << " bytes -> " << recompressed.size() <<
         " bytes (ratio = " << original_bytes / (float)recompressed.size() << ":1) ("
         << (recompressed.size() * 30 * 8) / 1000000.f << " Mbps @ 30 FPS)" << endl;
     cout << "Quantization+RVL+Zstd Speed: Compressed in " << (t6 - t5 + t4 - t3) / 1000.f << " msec. Decompressed in " << (t8 - t6) / 1000.f << " msec" << endl;


### PR DESCRIPTION
We encountered an error where using the compressor on images whose dimensions weren't multiples of the block size were having line artifacts. So to ensure that this issue doesn't silently occur in the future, we added some check for the values of the dimensions.